### PR TITLE
Update roles and permissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,10 @@ Metrics/BlockLength:
     - "config/environments/**/*.rb"
     - "config/initializers/**/*.rb"
 
+Metrics/MethodLength:
+  Exclude:
+    - "app/models/ability.rb"
+
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,7 @@ class Ability
     admin_user_permissions(user) if user.role_admin?
     tn_administration_user_permissions(user) if user.role_tn_administration?
     programm_user_permissions(user) if user.role_programm?
+    read_unit_user_permissions(user) if user.role_read_unit?
     allocation_user_permissions(user) if user.role_allocation?
     editor_user_permissions(user) if user.role_editor?
     midata_user_permissions(user) if user.midata_user?
@@ -25,7 +26,6 @@ class Ability
     can :read, FixedEvent
   end
 
-  # rubocop:disable Metrics/MethodLength
   def midata_user_permissions(user)
     can %i[read commit], Unit, al: { email: user.email }
     can %i[read commit], Unit, lagerleiter: { email: user.email }
@@ -45,7 +45,6 @@ class Ability
 
     assistant_leader_permission(user)
   end
-  # rubocop:enable Metrics/MethodLength
 
   def assistant_leader_permission(user)
     participants = Participant.where(role: %i[assistant_leader helper], email: user.email)
@@ -99,6 +98,7 @@ class Ability
     can :manage, ActivityCategory
     can :manage, Spot
     can :manage, Field
+    can :read, UnitActivityExecution
     cannot :delete, ActivityCategory, parent_id: nil
   end
 
@@ -106,9 +106,14 @@ class Ability
     programm_user_permissions(user)
 
     can :manage, UnitActivity
-    can :manage, Unit
     can :manage, UnitActivityExecution
-    can :manage, UnitVisitorDay
+  end
+
+  def read_unit_user_permissions(_user)
+    can :read, Unit
+    can :read, UnitActivity
+    can :read, UnitActivityExecution
+    can :read, UnitVisitorDay
   end
 
   def editor_user_permissions(_user)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -48,7 +48,7 @@ class Ability
   # rubocop:enable Metrics/MethodLength
 
   def assistant_leader_permission(user)
-    participants = Participant.assistant_leader.where(email: user.email)
+    participants = Participant.where(role: %i[assistant_leader helper], email: user.email)
     unit_ids = participants.map(&:unit_ids).flatten
     return if unit_ids.empty?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,8 @@ class User < ApplicationRecord
   validates :uid, presence: true
   validates :pbs_id, presence: true, allow_blank: true
 
-  bitfield :role_flags, :role_user, :role_admin, :role_programm, :role_tn_administration, :role_editor, :role_allocation
+  bitfield :role_flags, :role_user, :role_admin, :role_programm, :role_tn_administration, :role_editor,
+           :role_allocation, :role_read_unit
 
   def self.from_omniauth(auth)
     email = auth.info.email


### PR DESCRIPTION
- Teilnehmende mit der Rolle Helfer / Küche erhalten dieselben Rechte wie Hilfsleiter und Leiter
- Rolle _programm_ sieht neu welche Einheiten einer Durchführung zugeteilt worden sind
- Neue Rolle _read_unit_ welche Basisdaten und Zuteilung von Einheiten ansehen kann