### PR TITLE
feat: allow azure SSH access

### DIFF
--- a/.docker/entrypoints/azure-entrypoint.sh
+++ b/.docker/entrypoints/azure-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+# For explanation why this is needed:
+# https://docs.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session#use-ssh-support-with-custom-docker-images
+
+# To allow Azure SSH shell
+export > /root/.profile
+/usr/sbin/sshd
+
+su-exec app "$@"

--- a/.docker/ssh_setup.sh
+++ b/.docker/ssh_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ssh-keygen -A
+
+#prepare run dir
+if [ ! -d "/var/run/sshd" ]; then
+    mkdir -p /var/run/sshd
+fi

--- a/.docker/sshd_config
+++ b/.docker/sshd_config
@@ -1,0 +1,12 @@
+Port 			2222
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes
+Subsystem sftp internal-sftp


### PR DESCRIPTION
To be able to fully move to Azure app Services, we need a way to run
one-off commands in the container.
For more details see
https://docs.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session#use-ssh-support-with-custom-docker-images