### PR TITLE
Anpassungen TN-Admin

### DIFF
--- a/app/views/units/show.html.slim
+++ b/app/views/units/show.html.slim
@@ -106,6 +106,9 @@
           dt = t('activerecord.attributes.unit.departure_slot')
           dd = @unit.departure_slot
 
+          dt = t('activerecord.attributes.unit.transport_mode')
+          dd = @unit.transport_mode
+
           dt = t('activerecord.attributes.unit.hand_over_camp_at')
           dd = I18n.l(@unit.hand_over_camp_at) if @unit.hand_over_camp_at
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -102,10 +102,10 @@ de:
         activity_booking_phase: Buchungsphase
         al: AL
         amount_of_rovers: Anzahl zugelassene Einheits-Rover
-        arrival_slot: Anreise Slot
+        arrival_slot: Anlieferung Material
         coach: Coach
         definite_max_number_of_persons: Definitve maximale Personenanzahl
-        departure_slot: Abreise Slot
+        departure_slot: Abholung Material
         district: Quartier
         ends_at: Ende am
         expected_guest_leaders: Definitive Anzahl Internationale (Leitung)
@@ -126,9 +126,9 @@ de:
         starts_at: Beginn am
         stufe: Stufe
         title: Titel
+        transport_mode: Transportart
         visitor_day_tickets: Anzahl Tickets für den Besuchstag
         week: Lagerwoche
-        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Durchführung
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -128,6 +128,7 @@ de:
         title: Titel
         visitor_day_tickets: Anzahl Tickets für den Besuchstag
         week: Lagerwoche
+        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Durchführung
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,10 +102,10 @@ en:
         activity_booking_phase: Buchungsphase
         al: Group leader
         amount_of_rovers: Amount of rovers
-        arrival_slot: Arrival Slot
+        arrival_slot: Material Delivery
         coach: Coach
         definite_max_number_of_persons: Definite max number of persons
-        departure_slot: Departure Slot
+        departure_slot: Material pick up
         district: District
         ends_at: End on
         expected_guest_leaders: Erwartete Anzahl Gäste (Leitung)
@@ -126,9 +126,9 @@ en:
         starts_at: Start on
         stufe: Stufe
         title: Title
+        transport_mode: Type of Transport
         visitor_day_tickets: Anzahl Tickets für den Besuchstag
         week: Week
-        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Durchführung
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,7 @@ en:
         title: Title
         visitor_day_tickets: Anzahl Tickets für den Besuchstag
         week: Week
+        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Durchführung
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -102,10 +102,10 @@ fr:
         activity_booking_phase: Phase de réservation
         al: RG
         amount_of_rovers: Nombre de Rovers d'unité autorisé
-        arrival_slot: Créneau voyage aller
+        arrival_slot: Livraison du matériel
         coach: Coach
         definite_max_number_of_persons: Nombre maximum définitif de personnes
-        departure_slot: Créneau voyage retour
+        departure_slot: Retrait du matériel
         district: Quartier
         ends_at: Fin le
         expected_guest_leaders: Nombre définitif de responsables internationaux-ales
@@ -126,9 +126,9 @@ fr:
         starts_at: Début le
         stufe: Branche
         title: Titre
+        transport_mode: Mode de transport
         visitor_day_tickets: Anzahl Tickets für den Journée portes ouvertes
         week: Semaine de camp
-        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Activité
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -128,6 +128,7 @@ fr:
         title: Titre
         visitor_day_tickets: Anzahl Tickets für den Journée portes ouvertes
         week: Semaine de camp
+        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Activité
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -128,6 +128,7 @@ it:
         title: Titolo
         visitor_day_tickets: Anzahl Tickets für den Giornata delle visite
         week: Settimana di campo
+        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Attività
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -102,10 +102,10 @@ it:
         activity_booking_phase: Fase di prenotazione
         al: CSZ
         amount_of_rovers: Numero di rover dell'unità ammessi
-        arrival_slot: Slot viaggio di andata
+        arrival_slot: Consegna materiale
         coach: Coach
         definite_max_number_of_persons: Numero massimo di persone definitivo
-        departure_slot: Slot viaggio di ritorno
+        departure_slot: Ritiro materiale
         district: Quartiere
         ends_at: Fine il
         expected_guest_leaders: Numero definitivo di animatori/trici internazionali
@@ -126,9 +126,9 @@ it:
         starts_at: Inizio il
         stufe: Branca
         title: Titolo
+        transport_mode: Tipo di trasporto
         visitor_day_tickets: Anzahl Tickets für den Giornata delle visite
         week: Settimana di campo
-        transport_mode: Transportart
       unit_activity_execution:
         activity_execution_id: Attività
         change_notification: Änderungsbenachrichtigung an Einheit verschicken

--- a/db/migrate/20220429091116_add_transport_mode_to_unit.rb
+++ b/db/migrate/20220429091116_add_transport_mode_to_unit.rb
@@ -1,0 +1,5 @@
+class AddTransportModeToUnit < ActiveRecord::Migration[6.1]
+  def change
+    add_column :units, :transport_mode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_26_084532) do
+ActiveRecord::Schema.define(version: 2022_04_29_091116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -367,6 +367,7 @@ ActiveRecord::Schema.define(version: 2022_04_26_084532) do
     t.string "arrival_slot"
     t.string "departure_slot"
     t.datetime "hand_over_camp_at"
+    t.string "transport_mode"
     t.index ["al_id"], name: "index_units_on_al_id"
     t.index ["coach_id"], name: "index_units_on_coach_id"
     t.index ["lagerleiter_id"], name: "index_units_on_lagerleiter_id"


### PR DESCRIPTION
**Original Request**
> Hallo zusammen
> Ihr habe ja bereits vor einigen Wochen die Felder "Anreise Slot" und "Abreise Slot" erstellt. Könnte man diese Felder noch umbenennen in folgende Bezeichnungen:
> - Anlieferung Material
> - Abholung Material
>
> Auch ein zusätzliches Feld "Transportart" wäre super. Wenn es möglich wäre, hätte ich euch auch gleich die Daten zum einfüllen.
> Ist eine Publikation bis Ende Monat möglich?

**Questions**
Would be glad if someone could check my ruby-fu… (do I need to add the field to the model for example?)

Also `db:seed` is broken for me:

```ruby
NoMethodError: undefined method `visitor_day_tickets' for #<Unit id: nil, pbs_id: 1, title: "Sommerlager Pfadistufe", abteilung: "Pfadi H2O", kv_id: 166, stufe: "wolf", expected_participants_f: 12, expected_participants_m: 18, expected_participants_leitung_f: 9, expected_participants_leitung_m: 9, starts_at: "2021-07-10 00:00:00.000000000 +0200", ends_at: "2021-08-26 00:00:00.000000000 +0200", lagerleiter_id: 2, created_at: nil, updated_at: nil, limesurvey_token: "k1mIs8CB+50Zuw==", al_id: 1, coach_id: nil, midata_data: nil, language: nil, activity_booking_phase: nil>
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/attribute_methods.rb:469:in `method_missing'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validator.rb:150:in `block in validate'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validator.rb:149:in `each'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validator.rb:149:in `validate'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:427:in `block in make_lambda'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:604:in `block (2 levels) in default_terminator'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:603:in `catch'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:603:in `block in default_terminator'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:199:in `block in halting'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:512:in `block in invoke_before'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:512:in `each'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:512:in `invoke_before'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:105:in `run_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:824:in `_run_validate_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validations.rb:406:in `run_validations!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validations/callbacks.rb:117:in `block in run_validations!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:106:in `run_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:824:in `_run_validation_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validations/callbacks.rb:117:in `run_validations!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activemodel-6.1.5/lib/active_model/validations.rb:337:in `valid?'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/validations.rb:68:in `valid?'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/validations.rb:84:in `perform_validations'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/validations.rb:53:in `save!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/transactions.rb:302:in `block in save!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `block in within_new_transaction'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/connection_adapters/abstract/transaction.rb:317:in `within_new_transaction'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/transactions.rb:302:in `save!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/suppressor.rb:48:in `save!'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/configuration.rb:18:in `block in initialize'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/evaluation.rb:18:in `create'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy/create.rb:12:in `block in result'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy/create.rb:9:in `result'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/factory.rb:43:in `run'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/factory_runner.rb:29:in `block in run'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/notifications.rb:205:in `instrument'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/factory_runner.rb:28:in `run'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
/home/develop/app/db/seeds.rb:14:in `<main>'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:39:in `load'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:39:in `load'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/engine.rb:566:in `block in load_seed'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/execution_wrapper.rb:91:in `wrap'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/engine.rb:640:in `block (2 levels) in <class:Engine>'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:126:in `instance_exec'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:126:in `block in run_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.5/lib/active_support/callbacks.rb:137:in `run_callbacks'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/engine.rb:566:in `load_seed'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/tasks/database_tasks.rb:450:in `load_seed'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.5/lib/active_record/railties/databases.rake:392:in `block (2 levels) in <main>'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/commands/rake/rake_command.rb:24:in `block (2 levels) in perform'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/command.rb:50:in `invoke'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/railties-6.1.5/lib/rails/commands.rb:18:in `<main>'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/home/develop/app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
Tasks: TOP => db:seed
(See full trace by running task with --trace
```